### PR TITLE
remove double ,, in package.json template

### DIFF
--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -53,7 +53,7 @@
 		"grunt-grunticon": "^2.2.2",
 		"grunt-newer": "^1.1.1",
 		"grunt-scss-lint": "^0.3.8",
-		"grunt-shimly": "^1.0.1",,
+		"grunt-shimly": "^1.0.1",
 		"imagemin-gifsicle": "^4.2.0",
 		"imagemin-jpegtran": "^4.3.1",
 		"imagemin-mozjpeg": "^5.1.0",


### PR DESCRIPTION
this was breaking the `npm install` command that runs immediately after stepping through the generator options

![img](https://cloud.githubusercontent.com/assets/2393035/14762203/b029abe0-096c-11e6-96c6-eeb59a97cdb0.png)